### PR TITLE
Suggestion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "fleetfoot/otp",
-    "version": "0.0.1"
+    "version": "0.0.1",
     "description": "Laravel5 OTP manager",
     "keywords": ["laravel", "otp"],
     "license": "GPL",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "fleetfoot/otp",
+    "version": "0.0.1"
     "description": "Laravel5 OTP manager",
     "keywords": ["laravel", "otp"],
     "license": "GPL",

--- a/src/Exceptions/MaxAllowedAttemptsExceededException.php
+++ b/src/Exceptions/MaxAllowedAttemptsExceededException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Fleetfoot\OTP\Exceptions;
+
+use Exception;
+
+class MaxAllowedAttemptsExceededException extends Exception
+{
+    public function __contruct($message, $code = 0, Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Helpers/Generator.php
+++ b/src/Helpers/Generator.php
@@ -3,7 +3,7 @@
 namespace Fleetfoot\OTP\Helpers;
 
 use Config;
-use Fleetfoot\OTP\Models\OneTimePassword;
+use Fleetfoot\OTP\Models\OTP;
 
 /**
  * OTP generation facilitator.
@@ -14,7 +14,7 @@ class Generator
 
     public function __construct()
     {
-        $this->otpModel = new OneTimePassword;
+        $this->otpModel = new OTP;
     }
 
     /**
@@ -27,7 +27,7 @@ class Generator
      * @param string $module - requesting module
      * @param string $id     - ID of the requesting object
      *
-     * @return OneTimePassword $otp
+     * @return OTP $otp
      *
      */
     public function generate($module, $id)
@@ -42,7 +42,7 @@ class Generator
         if ($otp) {
             return $otp;
         } else {
-            $otp = new OneTimePassword;
+            $otp = new OTP;
         }
 
         $otp = $otp->generate($module, $id, Config::get('otp.size'));

--- a/src/Helpers/Validator.php
+++ b/src/Helpers/Validator.php
@@ -2,7 +2,7 @@
 
 namespace Fleetfoot\OTP\Helpers;
 
-use Fleetfoot\OTP\Models\OneTimePassword as OTP;
+use Fleetfoot\OTP\Models\OTP;
 use Fleetfoot\OTP\Models\OtpBlacklist;
 
 /**

--- a/src/Helpers/Validator.php
+++ b/src/Helpers/Validator.php
@@ -2,11 +2,15 @@
 
 namespace Fleetfoot\OTP\Helpers;
 
+use Fleetfoot\OTP\Exceptions\MaxAllowedAttemptsExceededException;
 use Fleetfoot\OTP\Models\OTP;
+use Fleetfoot\OTP\Models\OtpAttempt;
 use Fleetfoot\OTP\Models\OtpBlacklist;
+use Carbon\Carbon;
+use Config;
 
 /**
- * OTP validaty checker.
+ * OTP validity checker.
  */
 class Validator
 {
@@ -33,6 +37,12 @@ class Validator
             ->first();
 
         if (!$otp) {
+            if (!$this->isAttemptsExceeded($module, $id)) {
+                $this->_addAttempt($module, $id);
+            } else {
+                throw new MaxAllowedAttemptsExceededException("Max allowed attempts exceeded. Try again later.", 403);
+            }
+
             return false;
         }
 
@@ -67,5 +77,55 @@ class Validator
     public function getTrials($module, $id)
     {
         return (new OTP)->getTrialsCount($module, $id);
+    }
+
+    /**
+     * Check if attempts exceeded
+     *
+     * @param string $module
+     * @param string $id
+     *
+     * @return int
+     */
+    public function isAttemptsExceeded($module, $id)
+    {
+        if ($this->countAttempts($module, $id) >= Config::get('otp.allowed_attempts')) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get number of attempts made to validate OTP.
+     *
+     * @param string $module
+     * @param string $id
+     *
+     * @return int
+     */
+    public function countAttempts($module, $id)
+    {
+        return OtpAttempt::where('module', $module)
+            ->where('entity_id', $id)
+            ->where('created_at', '>=', Carbon::now()->subMinutes(Config::get('otp.attempts_count_time')))
+            ->count();
+    }
+
+    /**
+     * Write validate check attempt for (module + id).
+     * @param string $module
+     * @param string $id
+     *
+     * @return boolean
+     */
+    private function _addAttempt($module, $id)
+    {
+        $otpAttempt = new OtpAttempt;
+        $otpAttempt->module = $module;
+        $otpAttempt->entity_id = $id;
+        $otpAttempt->save();
+
+        return true;
     }
 }

--- a/src/Models/OTP.php
+++ b/src/Models/OTP.php
@@ -6,14 +6,14 @@ use Carbon\Carbon;
 use Config;
 use Illuminate\Database\Eloquent\Model;
 
-class OneTimePassword extends Model
+class OTP extends Model
 {
-    protected $table = 'one_time_passwords';
+    protected $table = 'otp';
     protected $dates = ['created_at', 'updated_at'];
 
     public function removeExpiredTokens()
     {
-        OneTimePassword::where('expires_on', '<=', Carbon::now())->delete();
+        OTP::where('expires_on', '<=', Carbon::now())->delete();
 
         return true;
     }
@@ -36,7 +36,7 @@ class OneTimePassword extends Model
 
     public function getTrialsCount($module, $id)
     {
-        $trials = OneTimePassword::whereModule($module)
+        return OTP::whereModule($module)
             ->whereEntityId($id)
             ->count();
     }

--- a/src/Models/OtpAttempt.php
+++ b/src/Models/OtpAttempt.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Fleetfoot\OTP\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class OtpAttempt extends Model
+{
+    protected $table = 'otp_attempts';
+    protected $dates = ['created_at', 'updated_at'];
+}

--- a/src/config/otp.php
+++ b/src/config/otp.php
@@ -10,7 +10,7 @@ return [
      * Duration in minutes after which the
      * code will expire.
      */
-    'expiry' => env('OTP_EXPIRY', 10),
+    'expiry' => env('OTP_EXPIRY', 20),
 
     /**
      * Maximum OTPs allowed to be generated
@@ -25,4 +25,14 @@ return [
      * Length of OTP
      */
     'size' => env('OTP_SIZE', 6),
+
+    /**
+     * Attempts count time in minutes
+     */
+    'attempts_count_time' => env('OTP_COUNT_TIME', 10),
+
+    /**
+     * Allowed attempts within duration of attempts_count_time
+     */
+    'allowed_attempts' => env('OTP_ALLOWED_ATTEMPTS', 5),
 ];

--- a/src/database/migrations/2016_11_14_150221_create_otp_table.php
+++ b/src/database/migrations/2016_11_14_150221_create_otp_table.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class CreateOneTimePasswordsTable extends Migration
+class CreateOtpTable extends Migration
 {
     /**
      * Run the migrations.
@@ -12,7 +12,7 @@ class CreateOneTimePasswordsTable extends Migration
      */
     public function up()
     {
-        Schema::create('one_time_passwords', function (Blueprint $table) {
+        Schema::create('otp', function (Blueprint $table) {
             $table->increments('id');
 
             $table->integer('token')->unsigned();
@@ -31,6 +31,6 @@ class CreateOneTimePasswordsTable extends Migration
      */
     public function down()
     {
-        Schema::drop('one_time_passwords');
+        Schema::drop('otp');
     }
 }

--- a/src/database/migrations/2016_11_15_054348_create_opt_attempts_table.php
+++ b/src/database/migrations/2016_11_15_054348_create_opt_attempts_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class CreateOptAttemptsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('otp_attempts', function (Blueprint $table) {
+            $table->increments('id');
+
+            $table->string('module');
+            $table->string('entity_id');
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('otp_attempts');
+    }
+}


### PR DESCRIPTION
Added different approach to limit users OTP check.

There some conflict beetwen blocking user and limiting otp attempts.
In my opinion we can remove blocking (call _block function) from generate function and make _block function public. Or add check to use only one of them.

Another suggestion is to add config option time_beetwen_generation in seconds format. And throw exception TimeBeetwenGenerationException if this time is less. E.g. you can generate code only once per 60 seconds (I have this limitation in my project but I chack it in sms sending with otp).

Tell me whot you think and I can try to make some changes.